### PR TITLE
add support for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "gunicorn-django-canonical-logs"
 dynamic = ["version"]
 description = "Canonical log lines for Django applications using Gunicorn sync workers"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,12 +16,12 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
-  "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = ["django", "gunicorn"]
 
@@ -54,7 +54,7 @@ extra-dependencies = [
 check = "mypy --install-types --non-interactive {args:src/gunicorn_django_canonical_logs tests}"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.10", "3.13"]
+python = ["3.9", "3.13"]
 django = ["4.2", "latest"]
 
 [tool.hatch.envs.hatch-test]

--- a/src/gunicorn_django_canonical_logs/logfmt.py
+++ b/src/gunicorn_django_canonical_logs/logfmt.py
@@ -77,6 +77,6 @@ class LogFmt:
         return " ".join(
             [
                 "=".join([cls.normalize_key(pair[0]), cls.format_value(pair[1])])
-                for pair in zip(*([iter(tokens)] * 2), strict=False)
+                for pair in zip(*([iter(tokens)] * 2))
             ]
         )


### PR DESCRIPTION
* Closes #6 

Turns out hatch only makes Python 3.7+ available...so no RHEL8 system Python support, using RHEL 9's system Python 3.9 as the default intstead.