### PR TITLE
Http instrumenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
   * [Default intstrumenters](#default-instrumenters)
     - [Request intstrumenter](#request-instrumenter)
     - [Exception intstrumenter](#exception-instrumenter)
-    - [Database intstrument](#database-instrumenter)
+    - [Database intstrumenter](#database-instrumenter)
+    - [HTTP intstrumenter](#http-instrumenter)
   * [Default monitors](#default-monitors)
     - [Saturation monitor](#saturation-monitor)
     - [Timeout monitor](#timeout-monitor)
@@ -259,6 +260,14 @@ g_memory_usage_mib="140"
 * `db_time` (`float`) - total time spent executing queries (in seconds)
 * `db_dup_queries` (`int`) - total number of non-unique queries; could indicate N+1 issues
 * `db_dup_time` (`float`) - total time spent executing non-unique queries (in seconds); could indicate N+1 issues
+
+#### HTTP instrumenter
+
+> [!NOTE]
+> Only instruments the `requests` library
+
+* `http_requests` (`int`) - total number of queries executed
+* `http_request_time` (`float`) - total time spent executing queries (in seconds)
 
 #### Saturation metrics
 

--- a/README.md
+++ b/README.md
@@ -266,8 +266,8 @@ g_memory_usage_mib="140"
 > [!NOTE]
 > Only instruments the `requests` library
 
-* `http_requests` (`int`) - total number of queries executed
-* `http_request_time` (`float`) - total time spent executing queries (in seconds)
+* `http_requests` (`int`) - total number of HTTP requests
+* `http_request_time` (`float`) - total time spent executing HTTP requests (in seconds)
 
 #### Saturation metrics
 

--- a/src/gunicorn_django_canonical_logs/instrumenters/__init__.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/__init__.py
@@ -8,6 +8,7 @@ from gunicorn_django_canonical_logs.instrumenters import (  # noqa F401 register
     database,
     exception,
     request,
+    http,
 )
 from gunicorn_django_canonical_logs.instrumenters.registry import instrumenter_registry
 

--- a/src/gunicorn_django_canonical_logs/instrumenters/__init__.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/__init__.py
@@ -7,8 +7,8 @@ from gunicorn_django_canonical_logs.gunicorn_hooks import register_hook
 from gunicorn_django_canonical_logs.instrumenters import (  # noqa F401 registers instrumenters
     database,
     exception,
-    request,
     http,
+    request,
 )
 from gunicorn_django_canonical_logs.instrumenters.registry import instrumenter_registry
 

--- a/src/gunicorn_django_canonical_logs/instrumenters/http.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/http.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import functools
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import ClassVar
+
+from requests.sessions import Session
+
+from gunicorn_django_canonical_logs.event_context import Context
+from gunicorn_django_canonical_logs.instrumenters.protocol import InstrumenterProtocol
+from gunicorn_django_canonical_logs.instrumenters.registry import register_instrumenter
+
+
+class HTTPRequestCollector:
+    _requests: ClassVar[dict[str, int | float]] = defaultdict(int)
+
+    @classmethod
+    def add(cls, duration: float):
+        cls._requests["count"] += 1
+        cls._requests["duration"] += duration
+
+    @classmethod
+    def reset(cls):
+        cls._requests.clear()
+
+    @classmethod
+    def get_data(cls):
+        return {
+            "requests": cls._requests["count"],
+            "request_time": cls._requests["duration"],
+        }
+
+    @classmethod
+    @contextmanager
+    def instrument(cls):
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            duration = time.monotonic() - start
+            cls.add(duration)
+
+
+@register_instrumenter
+class HTTPRequestInstrumenter(InstrumenterProtocol):
+    NAMESPACE = "http"
+
+    def __init__(self):
+        self._orig_send = Session.send
+
+    def setup(self):
+        Session.send = self._instrumented_send
+
+    def teardown(self):
+        Session.send = self._orig_send
+
+    def call(self, _req, _resp, _environ):
+        data = HTTPRequestCollector.get_data()
+        if data.get("requests", 0) > 0:
+            Context.update(namespace=self.NAMESPACE, context=data)
+        HTTPRequestCollector.reset()
+
+    @property
+    def _instrumented_send(self):
+        orig_send = self._orig_send
+
+        @functools.wraps(orig_send)
+        def instrumented_send(self, request, **kwargs):
+            with HTTPRequestCollector.instrument():
+                return orig_send(self, request, **kwargs)
+
+        return instrumented_send

--- a/tests/instrumenter_tests/test_http.py
+++ b/tests/instrumenter_tests/test_http.py
@@ -4,7 +4,7 @@ from collections.abc import Generator
 import pytest
 
 from gunicorn_django_canonical_logs.event_context import Context
-from gunicorn_django_canonical_logs.instrumenters.http import HTTPRequestInstrumenter, HTTPRequestCollector
+from gunicorn_django_canonical_logs.instrumenters.http import HTTPRequestCollector, HTTPRequestInstrumenter
 
 
 @pytest.fixture

--- a/tests/instrumenter_tests/test_http.py
+++ b/tests/instrumenter_tests/test_http.py
@@ -1,0 +1,63 @@
+# noqa INP001 intentionally not a package, part of pytest tests
+from collections.abc import Generator
+
+import pytest
+
+from gunicorn_django_canonical_logs.event_context import Context
+from gunicorn_django_canonical_logs.instrumenters.http import HTTPRequestInstrumenter, HTTPRequestCollector
+
+
+@pytest.fixture
+def instrumenter() -> Generator[HTTPRequestInstrumenter, None, None]:
+    Context.reset()
+    HTTPRequestCollector.reset()
+    instrumenter = HTTPRequestInstrumenter()
+    instrumenter.setup()
+    yield instrumenter
+    instrumenter.teardown()
+
+
+def test_requests(instrumenter, client):
+    Context.reset()
+    HTTPRequestCollector.reset()
+    resp = client.get("/http_requests/?count=3")
+    assert resp.status_code == 200
+
+    namespace = "http"
+
+    instrumenter.call(None, None, None)
+
+    assert Context.get("requests", namespace=namespace) == 3
+    assert float(Context.get("request_time", namespace=namespace)) > 0
+
+
+def test_collector_reset_on_call(instrumenter, client):
+    Context.reset()
+    HTTPRequestCollector.reset()
+    resp = client.get("/http_requests/")
+    assert resp.status_code == 200
+
+    namespace = "http"
+
+    instrumenter.call(None, None, None)
+
+    assert Context.get("requests", namespace=namespace) == 1
+    assert float(Context.get("request_time", namespace=namespace)) > 0
+
+    Context.reset()
+    instrumenter.call(None, None, None)
+
+    assert namespace not in dict(Context.raw_items())
+
+
+def test_does_not_set_context_if_no_http_requests(instrumenter, client):
+    Context.reset()
+    HTTPRequestCollector.reset()
+    resp = client.get("/ok/")
+    assert resp.status_code == 200
+
+    namespace = "http"
+
+    instrumenter.call(None, None, None)
+
+    assert namespace not in dict(Context.raw_items())

--- a/tests/server/app.py
+++ b/tests/server/app.py
@@ -84,7 +84,7 @@ def custom_timing(_):
 
 
 def sleep(request):
-    duration = float(request.GET["duration"])
+    duration = float(request.GET.get("duration", "1"))
     simulate_blocking(duration)
     return HttpResponse(f"Slept {duration} seconds!")
 
@@ -103,6 +103,13 @@ def db_queries(_):
     p.refresh_from_db()
     p.refresh_from_db()
     return HttpResponse("OK")
+
+
+def http_requests(request):
+    count = int(request.GET.get("count", "1"))
+    for _ in range(count):
+        requests.get("https://www.google.com", timeout=2)
+    return HttpResponse(f"Made {count} HTTP requests!")
 
 
 def simulate_blocking(duration):
@@ -129,6 +136,7 @@ urlpatterns = [
     path("sleep/", sleep),
     path("rude_sleep/", rude_sleep),
     path("db_queries/", db_queries),
+    path("http_requests/", http_requests),
     path("partial_failure/", partial_failure),
 ]
 

--- a/tests/server/app.py
+++ b/tests/server/app.py
@@ -108,7 +108,7 @@ def db_queries(_):
 def http_requests(request):
     count = int(request.GET.get("count", "1"))
     for _ in range(count):
-        requests.get("https://www.google.com", timeout=2)
+        requests.get("https://www.google.com", timeout=2).raise_for_status()
     return HttpResponse(f"Made {count} HTTP requests!")
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -194,6 +194,19 @@ def test_db_event(server) -> None:
     assert logs[0]["db_queries"] == "3"
 
 
+def test_http_request_event(server) -> None:
+    stdout, _ = server
+    clear_output(stdout)
+
+    requests.get("http://localhost:8080/http_requests/")
+
+    logs = get_parsed_canonical_logs(stdout)
+    assert len(logs) == 1
+    assert logs[0]["resp_status"] == "200"
+    assert logs[0]["http_requests"] == "1"
+    assert float(logs[0]["http_request_time"]) > 0
+
+
 def test_custom_event(server) -> None:
     stdout, _ = server
     clear_output(stdout)


### PR DESCRIPTION
* Closes #18 

Adds a minimal HTTP request instrumenter, intended to track HTTP API calls made during request processing.