### PR TITLE
Count timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,8 @@ with Context.time("custom"):
 ```
 
 This would add `app_custom_time="{wall time in seconds}"` to the log for the current request based on the execution
-time of `do_thing_that_takes_time()`; multiple timings using the same key are summed.
+time of `do_thing_that_takes_time()`; multiple timings using the same key are summed and a `app_custom_count` key is
+added for the call count.
 
 ### Custom instrumenters
 

--- a/src/gunicorn_django_canonical_logs/event_context.py
+++ b/src/gunicorn_django_canonical_logs/event_context.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import time
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
@@ -23,19 +22,11 @@ class EventContext:
 
     @contextmanager
     def time(self, key: str, *, namespace: str = DEFAULT_NAMESPACE) -> Generator[None, None, None]:
-        key = f"{key}_time"
-        try:
-            current_timing = float(self.get(key, namespace=namespace))
-        except (TypeError, ValueError):  # overrides value if it's not parseable as a float
-            current_timing = 0
-            self.set(key, current_timing, namespace=namespace)
-        start = time.monotonic()
-        try:
+        # HACK lazy import to get around circular dependency
+        from gunicorn_django_canonical_logs.instrumenters.custom_timing import CustomTimingCollector
+
+        with CustomTimingCollector.instrument(key, namespace):
             yield
-        finally:
-            timing = time.monotonic() - start
-            current_timing += timing
-            self.set(key, f"{current_timing:.3f}", namespace=namespace)
 
     def update(self, *, context: dict[str, Any], namespace: str = DEFAULT_NAMESPACE, beginning: bool = False) -> None:
         self._context[namespace].update(context)

--- a/src/gunicorn_django_canonical_logs/event_context.py
+++ b/src/gunicorn_django_canonical_logs/event_context.py
@@ -23,7 +23,7 @@ class EventContext:
     @contextmanager
     def time(self, key: str, *, namespace: str = DEFAULT_NAMESPACE) -> Generator[None, None, None]:
         # HACK lazy import to get around circular dependency
-        from gunicorn_django_canonical_logs.instrumenters.custom_timing import CustomTimingCollector
+        from gunicorn_django_canonical_logs.instrumenters.custom_timing import CustomTimingCollector  # noqa PLC0415
 
         with CustomTimingCollector.instrument(key, namespace):
             yield

--- a/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
@@ -26,7 +26,7 @@ class CustomTimingCollector:
 
     @classmethod
     def get_data(cls) -> dict[str, dict[str, int | float]]:
-        data: dict[str, dict[str, str, int | float]] = defaultdict(dict)
+        data: dict[str, dict[str, int | float]] = defaultdict(dict)
         for namespace, namespace_context in cls._data.items():
             for key in namespace_context:
                 data[namespace][f"{key}_time"] = cls._data[namespace][key]["duration"]

--- a/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import ClassVar
+
+from gunicorn_django_canonical_logs.event_context import Context
+from gunicorn_django_canonical_logs.instrumenters.protocol import InstrumenterProtocol
+from gunicorn_django_canonical_logs.instrumenters.registry import register_instrumenter
+
+
+class CustomTimingCollector:
+    _data: ClassVar[dict[str, dict[str, dict[str, int | float]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+    @classmethod
+    def add(cls, namespace, key, duration: float):
+        cls._data[namespace][key]["count"] += 1
+        cls._data[namespace][key]["duration"] += duration
+
+    @classmethod
+    def reset(cls):
+        cls._data.clear()
+
+    @classmethod
+    def get_data(cls) -> dict[str, dict[str, int | float]]:
+        data: dict[str, dict[str, str, int | float]] = defaultdict(dict)
+        for namespace, namespace_context in cls._data.items():
+            for key in namespace_context.keys():
+                data[namespace][f"{key}_time"] = cls._data[namespace][key]["duration"]
+                if cls._data[namespace][key]["count"] > 1:
+                    data[namespace][f"{key}_count"] = cls._data[namespace][key]["count"]
+        return data
+
+    @classmethod
+    @contextmanager
+    def instrument(cls, key, namespace):
+        start = time.monotonic()
+        try:
+            yield
+        finally:
+            duration = time.monotonic() - start
+            cls.add(namespace, key, duration)
+
+
+@register_instrumenter
+class CustomTimingInstrumenter(InstrumenterProtocol):
+    def call(self, _req, _resp, _environ):
+        data = CustomTimingCollector.get_data()
+        for namespace, namespace_context in data.items():
+            Context.update(context=namespace_context, namespace=namespace)
+        CustomTimingCollector.reset()

--- a/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
+++ b/src/gunicorn_django_canonical_logs/instrumenters/custom_timing.py
@@ -11,7 +11,9 @@ from gunicorn_django_canonical_logs.instrumenters.registry import register_instr
 
 
 class CustomTimingCollector:
-    _data: ClassVar[dict[str, dict[str, dict[str, int | float]]]] = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+    _data: ClassVar[dict[str, dict[str, dict[str, int | float]]]] = defaultdict(
+        lambda: defaultdict(lambda: defaultdict(int))
+    )
 
     @classmethod
     def add(cls, namespace, key, duration: float):
@@ -26,7 +28,7 @@ class CustomTimingCollector:
     def get_data(cls) -> dict[str, dict[str, int | float]]:
         data: dict[str, dict[str, str, int | float]] = defaultdict(dict)
         for namespace, namespace_context in cls._data.items():
-            for key in namespace_context.keys():
+            for key in namespace_context:
                 data[namespace][f"{key}_time"] = cls._data[namespace][key]["duration"]
                 if cls._data[namespace][key]["count"] > 1:
                     data[namespace][f"{key}_count"] = cls._data[namespace][key]["count"]

--- a/tests/instrumenter_tests/test_custom_timing.py
+++ b/tests/instrumenter_tests/test_custom_timing.py
@@ -1,0 +1,61 @@
+# noqa INP001 intentionally not a package, part of pytest tests
+import time
+from collections.abc import Generator
+
+import pytest
+
+from gunicorn_django_canonical_logs.event_context import Context
+from gunicorn_django_canonical_logs.instrumenters.custom_timing import CustomTimingCollector, CustomTimingInstrumenter
+
+
+@pytest.fixture
+def instrumenter() -> Generator[CustomTimingInstrumenter, None, None]:
+    Context.reset()
+    CustomTimingCollector.reset()
+    instrumenter = CustomTimingInstrumenter()
+    instrumenter.setup()
+    yield instrumenter
+    instrumenter.teardown()
+
+
+def test_time_without_namespace(instrumenter):
+    with Context.time("foo"):
+        time.sleep(0.2)
+
+    instrumenter.call(None, None, None)
+
+    assert 0.3 > float(Context.get("foo_time")) > 0.1
+
+
+def test_time_with_namespace(instrumenter):
+    with Context.time("foo", namespace="bar"):
+        time.sleep(0.2)
+
+    instrumenter.call(None, None, None)
+
+    assert 0.3 > float(Context.get("foo_time", namespace="bar")) > 0.1
+
+
+def test_time_overrides_existing_key_if_non_number(instrumenter):
+    Context.set("foo_time", "bar")
+
+    assert Context.get("foo_time") == "bar"
+
+    with Context.time("foo"):
+        time.sleep(0.2)
+
+    instrumenter.call(None, None, None)
+
+    assert 0.2 <= float(Context.get("foo_time")) < 0.3
+
+
+def test_time_sums_multiple_calls(instrumenter):
+    with Context.time("foo"):
+        time.sleep(0.2)
+
+    with Context.time("foo"):
+        time.sleep(0.2)
+
+    instrumenter.call(None, None, None)
+
+    assert 0.4 <= float(Context.get("foo_time")) < 0.5

--- a/tests/server/app.py
+++ b/tests/server/app.py
@@ -80,6 +80,12 @@ def custom_timing(_):
     with Context.time("custom"):
         time.sleep(0.2)
 
+    with Context.time("custom_multiple"):
+        time.sleep(0.2)
+
+    with Context.time("custom_multiple"):
+        time.sleep(0.2)
+
     return HttpResponse("OK!")
 
 

--- a/tests/test_event_context.py
+++ b/tests/test_event_context.py
@@ -1,5 +1,4 @@
 # noqa INP001 intentionally not a package, part of pytest tests
-import time
 
 from gunicorn_django_canonical_logs.event_context import EventContext
 

--- a/tests/test_event_context.py
+++ b/tests/test_event_context.py
@@ -16,46 +16,6 @@ def test_set_with_namespace():
     assert context.get("foo", namespace="baz") == "bar"
 
 
-def test_time_without_namespace():
-    context = EventContext()
-    with context.time("foo"):
-        time.sleep(0.2)
-
-    assert 0.3 > float(context.get("foo_time")) > 0.1
-
-
-def test_time_with_namespace():
-    context = EventContext()
-    with context.time("foo", namespace="bar"):
-        time.sleep(0.2)
-
-    assert 0.3 > float(context.get("foo_time", namespace="bar")) > 0.1
-
-
-def test_time_overrides_existing_key_if_non_number():
-    context = EventContext()
-    context.set("foo_time", "bar")
-
-    assert context.get("foo_time") == "bar"
-
-    with context.time("foo"):
-        time.sleep(0.2)
-
-    assert 0.2 <= float(context.get("foo_time")) < 0.3
-
-
-def test_time_sums_multiple_calls():
-    context = EventContext()
-
-    with context.time("foo"):
-        time.sleep(0.2)
-
-    with context.time("foo"):
-        time.sleep(0.2)
-
-    assert 0.4 <= float(context.get("foo_time")) < 0.5
-
-
 def test_update_without_namespace():
     context = EventContext()
     context.update(context={"foo": "bar"})

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -227,6 +227,9 @@ def test_custom_timing(server) -> None:
     logs = get_parsed_canonical_logs(stdout)
     assert len(logs) == 1
     assert re.search(r"0.2\d{2}", logs[0]["app_custom_time"])
+    assert logs[0].get("app_custom_count") is None
+    assert re.search(r"0.4\d{2}", logs[0]["app_custom_multiple_time"])
+    assert "2", logs[0]["app_custom_multiple_count"]
 
 
 def test_app_instrumenter(server) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -229,7 +229,7 @@ def test_custom_timing(server) -> None:
     assert re.search(r"0.2\d{2}", logs[0]["app_custom_time"])
     assert logs[0].get("app_custom_count") is None
     assert re.search(r"0.4\d{2}", logs[0]["app_custom_multiple_time"])
-    assert "2", logs[0]["app_custom_multiple_count"]
+    assert logs[0]["app_custom_multiple_count"] == "2"
 
 
 def test_app_instrumenter(server) -> None:


### PR DESCRIPTION
* Closes #22 

I'm a _little_ curious about whether this makes sense.

Collectors might deserve their own class files to break the circular dependency?

Context can expose user-facing stuff via collectors. Instrumenters leverage collectors and context?

The whole collectors vs instrumenters thing feels weird right now. Collectors feel finicky to write because there's not a well-defined interface for them, but it feels like there _should_ be. The fact that the custom timing collector exposes an `instrument` method also feels weird. 